### PR TITLE
Feature: Add converte Array of Object

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -40,3 +40,21 @@ describe('convert object properties', () => {
     expect(toSnake(camelCased)).toEqual(snakeCased);
   });
 });
+
+describe('convert array of objects properties', () => {
+  const camelCased = [
+    { fooBar: 'fooBar', barBaz: 1 },
+    { fooBar: 'foo', quxBar: 'bar' }
+  ];
+  const snakeCased = [
+    { foo_bar: 'fooBar', bar_baz: 1 },
+    { foo_bar: 'foo', qux_bar: 'bar' }
+  ];
+  it('from camelCase to snake_case', () => {
+    expect(toCamel(snakeCased)).toEqual(camelCased);
+  });
+
+  it('from snake_case to camelCase', () => {
+    expect(toSnake(camelCased)).toEqual(snakeCased);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,12 @@ type AnyObject = {
   [key: string]: any;
 };
 type Data = AnyObject | AnyObject[];
+type Converter = (str: string) => string;
+type Recursive = (obj: AnyObject) => AnyObject;
+type NameConverter = (converter: Converter) => <D extends Data>(data: D) => D;
 
-export const camel = (str: string) => str.replace(/_+(.?)/g, (_, p1) => p1.toUpperCase());
-export const snake = (str: string) =>
+export const camel: Converter = (str) => str.replace(/_+(.?)/g, (_, p1) => p1.toUpperCase());
+export const snake: Converter = (str) =>
   str
     .replace(/(^[A-Z])/, (_, p1) => p1.toLowerCase())
     .replace(/([A-Z]+)/g, (_, p1) => `_${p1.toLowerCase()}`);
@@ -16,10 +19,10 @@ const detectObject = (obj: any) => {
   return false;
 };
 
-const propertyNameConverter = (converterFn: (s: string) => string) => <P extends Data>(data: P): P => {
-  const recursive = (obj: AnyObject): AnyObject => {
+const propertyNameConverter: NameConverter = (converterFn) => (data) => {
+  const recursive: Recursive = (obj) => {
     const keys = data ? Object.keys(obj) : [];
-    return keys.reduce((accum: object, curr: string) => {
+    return keys.reduce((accum, curr) => {
       const propName = curr;
       const propValue = obj[propName];
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,7 @@ export const snake: Converter = (str) =>
     .replace(/(^[A-Z])/, (_, p1) => p1.toLowerCase())
     .replace(/([A-Z]+)/g, (_, p1) => `_${p1.toLowerCase()}`);
 
-const detectObject = (obj: any) => {
-  if (Object.prototype.toString.call(obj) === '[object Object]') {
-    return true;
-  }
-  return false;
-};
+const detectObject = (obj: any) => Object.prototype.toString.call(obj) === '[object Object]';
 
 const propertyNameConverter: NameConverter = (converterFn) => (data) => {
   const recursive: Recursive = (obj) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 type AnyObject = {
   [key: string]: any;
 };
+type Data = AnyObject | AnyObject[];
 
 export const camel = (str: string) => str.replace(/_+(.?)/g, (_, p1) => p1.toUpperCase());
 export const snake = (str: string) =>
@@ -15,7 +16,7 @@ const detectObject = (obj: any) => {
   return false;
 };
 
-const propertyNameConverter = (converterFn: (s: string) => string) => (data: AnyObject): object => {
+const propertyNameConverter = (converterFn: (s: string) => string) => <P extends Data>(data: P): P => {
   const recursive = (obj: AnyObject): AnyObject => {
     const keys = data ? Object.keys(obj) : [];
     return keys.reduce((accum: object, curr: string) => {
@@ -31,7 +32,7 @@ const propertyNameConverter = (converterFn: (s: string) => string) => (data: Any
       };
     }, {});
   };
-  return recursive(data);
+  return recursive({ key: data }).key;
 };
 
 export const toSnake = propertyNameConverter(snake);


### PR DESCRIPTION
Hello,

Thank you for your library.
I allow myself a small contribution because I noticed that your library does not take into account the case for the original was given an array of javacript object.

example:
```javascript
toCamel(
  [ // <== ARRAY
    { fooBar: 'fooBar', barBaz: 1 },
    { fooBar: 'foo', quxBar: 'bar' }
  ]
);
// yields
// { <== OBJECT
//    { fooBar: 'fooBar', barBaz: 1 },
//    { fooBar: 'foo', quxBar: 'bar' }
// }
```

I allows some optimization of typing and code.

Regards. 